### PR TITLE
Sirius Desktop 7.3.0

### DIFF
--- a/buildship.aggrcon
+++ b/buildship.aggrcon
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="ASCII"?>
 <aggregator:Contribution xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:aggregator="http://www.eclipse.org/cbi/p2repo/2011/aggregator/1.1.0" description="Buildship: Eclipse Plug-ins for Gradle" label="Buildship">
-  <repositories location="https://download.eclipse.org/buildship/updates/e427/releases/3.x/3.1.7.v20230428-1350">
-    <features name="org.eclipse.buildship.feature.group" versionRange="3.1.7">
+  <repositories location="https://download.eclipse.org/buildship/updates/e427/releases/3.x/3.1.8.v20231117-1658">
+    <features name="org.eclipse.buildship.feature.group" versionRange="3.1.8">
       <categories href="simrel.aggr#//@customCategories[identifier='General%20Purpose%20Tools']"/>
     </features>
   </repositories>

--- a/cdt.aggrcon
+++ b/cdt.aggrcon
@@ -1,21 +1,21 @@
 <?xml version="1.0" encoding="ASCII"?>
 <aggregator:Contribution xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:aggregator="http://www.eclipse.org/cbi/p2repo/2011/aggregator/1.1.0" label="CDT">
-  <repositories location="https://download.eclipse.org/tools/cdt/builds/11.4/cdt-11.4.0-m3/" description="CDT updates">
+  <repositories location="https://download.eclipse.org/tools/cdt/builds/11.4/cdt-11.4.0-rc1a/" description="CDT updates">
     <bundles name="org.eclipse.cdt.core.linux" versionRange="[6.1.0.202211062329]"/>
-    <bundles name="org.eclipse.cdt.core.linux.x86_64" versionRange="[11.4.0.202311151811]"/>
-    <bundles name="org.eclipse.cdt.core.macosx" versionRange="[11.4.0.202311151811]"/>
+    <bundles name="org.eclipse.cdt.core.linux.x86_64" versionRange="[11.4.0.202311211902]"/>
+    <bundles name="org.eclipse.cdt.core.macosx" versionRange="[11.4.0.202311211902]"/>
     <bundles name="org.eclipse.cdt.core.win32" versionRange="[6.1.0.202211062329]"/>
-    <bundles name="org.eclipse.cdt.core.linux.aarch64" versionRange="[11.4.0.202311151811]"/>
-    <features name="org.eclipse.cdt.feature.group" versionRange="[11.4.0.202311151811]">
+    <bundles name="org.eclipse.cdt.core.linux.aarch64" versionRange="[11.4.0.202311211902]"/>
+    <features name="org.eclipse.cdt.feature.group" versionRange="[11.4.0.202311211902]">
       <categories href="simrel.aggr#//@customCategories[identifier='Programming%20Languages']"/>
     </features>
-    <features name="org.eclipse.cdt.sdk.feature.group" versionRange="[11.4.0.202311151811]">
+    <features name="org.eclipse.cdt.sdk.feature.group" versionRange="[11.4.0.202311211902]">
       <categories href="simrel.aggr#//@customCategories[identifier='Programming%20Languages']"/>
     </features>
     <features name="org.eclipse.cdt.debug.gdbjtag.feature.group" versionRange="[11.4.0.202309151124]">
       <categories href="simrel.aggr#//@customCategories[identifier='Mobile%20and%20Device%20Development']"/>
     </features>
-    <features name="org.eclipse.cdt.platform.feature.group" versionRange="[11.4.0.202311151811]"/>
+    <features name="org.eclipse.cdt.platform.feature.group" versionRange="[11.4.0.202311211902]"/>
     <features name="org.eclipse.cdt.debug.ui.memory.feature.group" versionRange="[11.4.0.202309151124]">
       <categories href="simrel.aggr#//@customCategories[identifier='Mobile%20and%20Device%20Development']"/>
     </features>
@@ -45,7 +45,7 @@
     <features name="org.eclipse.cdt.docker.launcher.feature.group" versionRange="[11.4.0.202309151124]">
       <categories href="simrel.aggr#//@customCategories[identifier='Programming%20Languages']"/>
     </features>
-    <features name="org.eclipse.cdt.debug.standalone.feature.group" versionRange="[11.4.0.202311151803]"/>
+    <features name="org.eclipse.cdt.debug.standalone.feature.group" versionRange="[11.4.0.202311211857]"/>
     <features name="org.eclipse.cdt.cmake.feature.group" versionRange="[11.4.0.202309191802]"/>
     <features name="org.eclipse.cdt.launch.serial.feature.feature.group" versionRange="[11.4.0.202309142347]"/>
     <features name="org.eclipse.tm.terminal.connector.remote.feature.feature.group" versionRange="[11.4.0.202309151124]">

--- a/dtp.aggrcon
+++ b/dtp.aggrcon
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="ASCII"?>
-<aggregator:Contribution xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:aggregator="http://www.eclipse.org/cbi/p2repo/2011/aggregator/1.1.0" label="DataTools 1.15.0">
-  <repositories location="https://download.eclipse.org/datatools/updates/milestone/S202311081341" description="DataTools 1.16.0">
+<aggregator:Contribution xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:aggregator="http://www.eclipse.org/cbi/p2repo/2011/aggregator/1.1.0" label="DataTools 1.16.0">
+  <repositories location="https://download.eclipse.org/datatools/updates/release/1.16.0" description="DataTools 1.16.0">
     <features name="org.eclipse.datatools.common.doc.user.feature.group">
       <categories href="simrel.aggr#//@customCategories[identifier='Database%20Development']"/>
     </features>

--- a/ecf.aggrcon
+++ b/ecf.aggrcon
@@ -9,10 +9,6 @@
       <categories href="simrel.aggr#//@customCategories[identifier='Collaboration']"/>
       <categories href="simrel.aggr#//@customCategories[identifier='EclipseRT%20Target%20Platform%20Components']"/>
     </features>
-    <features name="org.eclipse.ecf.filetransfer.httpclient5.feature.feature.group" versionRange="[1.1.702.v20231114-1017]">
-      <categories href="simrel.aggr#//@customCategories[identifier='Collaboration']"/>
-      <categories href="simrel.aggr#//@customCategories[identifier='EclipseRT%20Target%20Platform%20Components']"/>
-    </features>
   </repositories>
   <contacts href="simrel.aggr#//@contacts[email='slewis@composent.com']"/>
 </aggregator:Contribution>

--- a/egit.aggrcon
+++ b/egit.aggrcon
@@ -1,31 +1,31 @@
 <?xml version="1.0" encoding="ASCII"?>
 <aggregator:Contribution xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:aggregator="http://www.eclipse.org/cbi/p2repo/2011/aggregator/1.1.0" label="EGit">
-  <repositories location="https://download.eclipse.org/egit/staging/v6.8.0.202311151710-m2" description="EGit Updates">
-    <features name="org.eclipse.jgit.feature.group" versionRange="[6.8.0.202311151710-m2]">
+  <repositories location="https://download.eclipse.org/egit/staging/v6.8.0.202311212206-rc1" description="EGit Updates">
+    <features name="org.eclipse.jgit.feature.group" versionRange="[6.8.0.202311212206-rc1]">
       <categories href="simrel.aggr#//@customCategories[identifier='Collaboration']"/>
     </features>
-    <features name="org.eclipse.jgit.pgm.feature.group" versionRange="[6.8.0.202311151710-m2]"/>
-    <features name="org.eclipse.egit.feature.group" versionRange="[6.8.0.202311151710-m2]">
+    <features name="org.eclipse.jgit.pgm.feature.group" versionRange="[6.8.0.202311212206-rc1]"/>
+    <features name="org.eclipse.egit.feature.group" versionRange="[6.8.0.202311212206-rc1]">
       <categories href="simrel.aggr#//@customCategories[identifier='Collaboration']"/>
     </features>
-    <features name="org.eclipse.egit.source.feature.group" versionRange="[6.8.0.202311151710-m2]"/>
-    <features name="org.eclipse.jgit.source.feature.group" versionRange="[6.8.0.202311151710-m2]"/>
-    <features name="org.eclipse.jgit.http.apache.feature.group" versionRange="[6.8.0.202311151710-m2]">
+    <features name="org.eclipse.egit.source.feature.group" versionRange="[6.8.0.202311212206-rc1]"/>
+    <features name="org.eclipse.jgit.source.feature.group" versionRange="[6.8.0.202311212206-rc1]"/>
+    <features name="org.eclipse.jgit.http.apache.feature.group" versionRange="[6.8.0.202311212206-rc1]">
       <categories href="simrel.aggr#//@customCategories[identifier='Collaboration']"/>
     </features>
-    <features name="org.eclipse.egit.gitflow.feature.feature.group" versionRange="[6.8.0.202311151710-m2]">
+    <features name="org.eclipse.egit.gitflow.feature.feature.group" versionRange="[6.8.0.202311212206-rc1]">
       <categories href="simrel.aggr#//@customCategories[identifier='Collaboration']"/>
     </features>
-    <features name="org.eclipse.jgit.ssh.apache.feature.group" versionRange="[6.8.0.202311151710-m2]">
+    <features name="org.eclipse.jgit.ssh.apache.feature.group" versionRange="[6.8.0.202311212206-rc1]">
       <categories href="simrel.aggr#//@customCategories[identifier='Collaboration']"/>
     </features>
-    <features name="org.eclipse.jgit.lfs.feature.group" versionRange="[6.8.0.202311151710-m2]">
+    <features name="org.eclipse.jgit.lfs.feature.group" versionRange="[6.8.0.202311212206-rc1]">
       <categories href="simrel.aggr#//@customCategories[identifier='Collaboration']"/>
     </features>
-    <features name="org.eclipse.jgit.gpg.bc.feature.group" versionRange="[6.8.0.202311151710-m2]">
+    <features name="org.eclipse.jgit.gpg.bc.feature.group" versionRange="[6.8.0.202311212206-rc1]">
       <categories href="simrel.aggr#//@customCategories[identifier='Collaboration']"/>
     </features>
-    <features name="org.eclipse.jgit.ssh.jsch.feature.group" versionRange="[6.8.0.202311151710-m2]">
+    <features name="org.eclipse.jgit.ssh.jsch.feature.group" versionRange="[6.8.0.202311212206-rc1]">
       <categories href="simrel.aggr#//@customCategories[identifier='Collaboration']"/>
     </features>
   </repositories>

--- a/emf-cdo.aggrcon
+++ b/emf-cdo.aggrcon
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <aggregator:Contribution xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:aggregator="http://www.eclipse.org/cbi/p2repo/2011/aggregator/1.1.0" label="EMF CDO">
-  <repositories location="https://download.eclipse.org/modeling/emf/cdo/drops/R20230906-0630" description="EMF CDO">
+  <repositories location="https://download.eclipse.org/modeling/emf/cdo/drops/S20231122-0705" description="EMF CDO">
     <features name="org.eclipse.net4j.sdk.feature.group">
       <categories href="simrel.aggr#//@customCategories[identifier='Collaboration']"/>
       <categories href="simrel.aggr#//@customCategories[identifier='Application%20Development%20Frameworks']"/>

--- a/emf-compare.aggrcon
+++ b/emf-compare.aggrcon
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="ASCII"?>
 <aggregator:Contribution xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:aggregator="http://www.eclipse.org/cbi/p2repo/2011/aggregator/1.1.0" label="EMF Compare">
-  <repositories location="https://download.eclipse.org/modeling/emf/compare/updates/releases/3.3/R202212280858/">
+  <repositories location="https://download.eclipse.org/modeling/emf/compare/updates/milestones/3.3/S202311200811/">
     <features name="org.eclipse.emf.compare.feature.group" versionRange="[3.3.0,3.4.0)"/>
     <features name="org.eclipse.emf.compare.source.feature.group" versionRange="[3.3.0,3.4.0)"/>
     <features name="org.eclipse.emf.compare.ide.ui.feature.group" versionRange="[3.3.0,3.4.0)">

--- a/emf-emf-rap.aggrcon
+++ b/emf-emf-rap.aggrcon
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="ASCII"?>
 <aggregator:Contribution xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:aggregator="http://www.eclipse.org/cbi/p2repo/2011/aggregator/1.1.0" label="EMF RAP (Runtime)">
-  <repositories location="https://download.eclipse.org/modeling/emf/emf/builds/milestone/S202311070643" description="EMF 2.36">
+  <repositories location="https://download.eclipse.org/modeling/emf/emf/builds/release/2.36.0" description="EMF 2.36">
     <features name="org.eclipse.emf.rap.sdk.feature.group">
       <categories href="simrel.aggr#//@customCategories[identifier='EclipseRT%20Target%20Platform%20Components']"/>
     </features>

--- a/emf-emf.aggrcon
+++ b/emf-emf.aggrcon
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="ASCII"?>
 <aggregator:Contribution xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:aggregator="http://www.eclipse.org/cbi/p2repo/2011/aggregator/1.1.0" label="EMF (Core)">
-  <repositories location="https://download.eclipse.org/modeling/emf/emf/builds/milestone/S202311070643" description="EMF 2.36">
+  <repositories location="https://download.eclipse.org/modeling/emf/emf/builds/release/2.36.0" description="EMF 2.36">
     <features name="org.eclipse.emf.sdk.feature.group">
       <categories href="simrel.aggr#//@customCategories[identifier='Modeling']"/>
       <categories href="simrel.aggr#//@customCategories[identifier='EclipseRT%20Target%20Platform%20Components']"/>

--- a/emf-parsley.aggrcon
+++ b/emf-parsley.aggrcon
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="ASCII"?>
 <aggregator:Contribution xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:aggregator="http://www.eclipse.org/cbi/p2repo/2011/aggregator/1.1.0" label="EMF Parsley">
-  <repositories location="https://download.eclipse.org/emf-parsley/updates/1.15/1.15.0.v20231121-1609/" description="EMF Parsley">
+  <repositories location="https://download.eclipse.org/emf-parsley/updates/1.15/1.15.0.v20231125-1306/" description="EMF Parsley">
     <features name="org.eclipse.emf.parsley.sdk.feature.group">
       <categories href="simrel.aggr#//@customCategories[identifier='Modeling']"/>
     </features>

--- a/emf-parsley.aggrcon
+++ b/emf-parsley.aggrcon
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="ASCII"?>
 <aggregator:Contribution xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:aggregator="http://www.eclipse.org/cbi/p2repo/2011/aggregator/1.1.0" label="EMF Parsley">
-  <repositories location="https://download.eclipse.org/emf-parsley/updates/1.14/1.14.0.v20221201-1038/" description="EMF Parsley">
+  <repositories location="https://download.eclipse.org/emf-parsley/milestones/1.15/1.15.0.v20231116-1508/" description="EMF Parsley">
     <features name="org.eclipse.emf.parsley.sdk.feature.group">
       <categories href="simrel.aggr#//@customCategories[identifier='Modeling']"/>
     </features>

--- a/emf-parsley.aggrcon
+++ b/emf-parsley.aggrcon
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="ASCII"?>
 <aggregator:Contribution xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:aggregator="http://www.eclipse.org/cbi/p2repo/2011/aggregator/1.1.0" label="EMF Parsley">
-  <repositories location="https://download.eclipse.org/emf-parsley/milestones/1.15/1.15.0.v20231116-1508/" description="EMF Parsley">
+  <repositories location="https://download.eclipse.org/emf-parsley/updates/1.15/1.15.0.v20231121-1609/" description="EMF Parsley">
     <features name="org.eclipse.emf.parsley.sdk.feature.group">
       <categories href="simrel.aggr#//@customCategories[identifier='Modeling']"/>
     </features>

--- a/emft-mwe.aggrcon
+++ b/emft-mwe.aggrcon
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="ASCII"?>
 <aggregator:Contribution xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:aggregator="http://www.eclipse.org/cbi/p2repo/2011/aggregator/1.1.0" label="EMFT MWE for 2023-12">
-  <repositories location="https://download.eclipse.org/modeling/emft/mwe/updates/releases/2.16.0/" description="MWE2 Language p2 repository" mirrorArtifacts="false">
+  <repositories location="https://download.eclipse.org/modeling/emft/mwe/updates/releases/2.16.0/" description="MWE2 Language p2 repository">
     <features name="org.eclipse.emf.mwe2.runtime.sdk.feature.group" versionRange="[2.16.0.v20231117-0522]">
       <categories href="simrel.aggr#//@customCategories[identifier='Modeling']"/>
     </features>

--- a/emft-mwe.aggrcon
+++ b/emft-mwe.aggrcon
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="ASCII"?>
 <aggregator:Contribution xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:aggregator="http://www.eclipse.org/cbi/p2repo/2011/aggregator/1.1.0" label="EMFT MWE for 2023-12">
-  <repositories location="https://download.eclipse.org/modeling/emft/mwe/updates/milestones/S202311100605/" description="MWE2 Language p2 repository">
-    <features name="org.eclipse.emf.mwe2.runtime.sdk.feature.group" versionRange="[2.16.0.v20231110-0605]">
+  <repositories location="https://download.eclipse.org/modeling/emft/mwe/updates/releases/2.16.0/" description="MWE2 Language p2 repository" mirrorArtifacts="false">
+    <features name="org.eclipse.emf.mwe2.runtime.sdk.feature.group" versionRange="[2.16.0.v20231117-0522]">
       <categories href="simrel.aggr#//@customCategories[identifier='Modeling']"/>
     </features>
-    <features name="org.eclipse.emf.mwe.sdk.feature.group" versionRange="[1.10.0.v20231110-0605]">
+    <features name="org.eclipse.emf.mwe.sdk.feature.group" versionRange="[1.10.0.v20231117-0522]">
       <categories href="simrel.aggr#//@customCategories[identifier='Modeling']"/>
     </features>
-    <features name="org.eclipse.emf.mwe2.language.sdk.feature.group" versionRange="[2.16.0.v20231110-0605]">
+    <features name="org.eclipse.emf.mwe2.language.sdk.feature.group" versionRange="[2.16.0.v20231117-0522]">
       <categories href="simrel.aggr#//@customCategories[identifier='Modeling']"/>
     </features>
   </repositories>

--- a/ep.aggrcon
+++ b/ep.aggrcon
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="ASCII"?>
 <aggregator:Contribution xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:aggregator="http://www.eclipse.org/cbi/p2repo/2011/aggregator/1.1.0" label="Eclipse">
-  <repositories location="https://download.eclipse.org/eclipse/updates/4.30-I-builds/I20231109-0710" description="Eclipse and Equinox">
+  <repositories location="https://download.eclipse.org/eclipse/updates/4.30-I-builds/I20231115-1800" description="Eclipse and Equinox">
     <products name="org.eclipse.sdk.ide"/>
     <products name="org.eclipse.platform.ide"/>
     <bundles name="org.eclipse.e4.ui.progress"/>

--- a/ep.aggrcon
+++ b/ep.aggrcon
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="ASCII"?>
 <aggregator:Contribution xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:aggregator="http://www.eclipse.org/cbi/p2repo/2011/aggregator/1.1.0" label="Eclipse">
-  <repositories location="https://download.eclipse.org/eclipse/updates/4.30-I-builds/I20231115-1800" description="Eclipse and Equinox">
+  <repositories location="https://download.eclipse.org/eclipse/updates/4.30-I-builds/I20231123-1700" description="Eclipse and Equinox">
     <products name="org.eclipse.sdk.ide"/>
     <products name="org.eclipse.platform.ide"/>
     <bundles name="org.eclipse.e4.ui.progress"/>

--- a/epp-mpc.aggrcon
+++ b/epp-mpc.aggrcon
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="ASCII"?>
 <aggregator:Contribution xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:aggregator="http://www.eclipse.org/cbi/p2repo/2011/aggregator/1.1.0" label="EPP Marketplace Client">
-  <repositories location="https://download.eclipse.org/mpc/drops/1.10.1/v20221110-1841/" description="EPP Marketplace Client">
-    <features name="org.eclipse.epp.mpc.feature.group" versionRange="[1.10.1,1.10.2)">
+  <repositories location="https://download.eclipse.org/mpc/drops/1.10.2/v20231116-1812/" description="EPP Marketplace Client">
+    <features name="org.eclipse.epp.mpc.feature.group" versionRange="[1.10.2,1.10.3)">
       <categories href="simrel.aggr#//@customCategories[identifier='General%20Purpose%20Tools']"/>
     </features>
-    <features name="org.eclipse.epp.mpc.source.feature.group" versionRange="[1.10.1,1.10.2)"/>
+    <features name="org.eclipse.epp.mpc.source.feature.group" versionRange="[1.10.2,1.10.3)"/>
   </repositories>
   <contacts href="simrel.aggr#//@contacts[email='wayne@eclipse.org']"/>
   <contacts href="simrel.aggr#//@contacts[email='reckord@yatta.de']"/>

--- a/gef.aggrcon
+++ b/gef.aggrcon
@@ -8,38 +8,38 @@
       <categories href="simrel.aggr#//@customCategories[identifier='Modeling']"/>
     </features>
   </repositories>
-  <repositories location="https://download.eclipse.org/tools/gef/updates/releases/5.4.0_gef-master_6893/" description="GEF Releases">
-    <features name="org.eclipse.gef.common.sdk.feature.group" versionRange="[5.0.1.202209120200]">
+  <repositories location="https://download.eclipse.org/tools/gef/fx/milestone/S202311221639" description="GEF Releases">
+    <features name="org.eclipse.gef.common.sdk.feature.group" versionRange="[5.0.1.202311221639]">
       <categories href="simrel.aggr#//@customCategories[identifier='Application%20Development%20Frameworks']"/>
     </features>
-    <features name="org.eclipse.gef.geometry.sdk.feature.group" versionRange="[5.0.3.202209120200]">
+    <features name="org.eclipse.gef.geometry.sdk.feature.group" versionRange="[5.0.3.202311221639]">
       <categories href="simrel.aggr#//@customCategories[identifier='Application%20Development%20Frameworks']"/>
     </features>
-    <features name="org.eclipse.gef.graph.sdk.feature.group" versionRange="[5.1.0.202209120200]">
+    <features name="org.eclipse.gef.graph.sdk.feature.group" versionRange="[5.1.0.202311221639]">
       <categories href="simrel.aggr#//@customCategories[identifier='Application%20Development%20Frameworks']"/>
     </features>
-    <features name="org.eclipse.gef.layout.sdk.feature.group" versionRange="[5.0.0.202209120200]">
+    <features name="org.eclipse.gef.layout.sdk.feature.group" versionRange="[5.0.0.202311221639]">
       <categories href="simrel.aggr#//@customCategories[identifier='Application%20Development%20Frameworks']"/>
     </features>
-    <features name="org.eclipse.gef.dot.sdk.feature.group" versionRange="[5.1.3.202209120200]">
+    <features name="org.eclipse.gef.dot.sdk.feature.group" versionRange="[5.1.3.202311221639]">
       <categories href="simrel.aggr#//@customCategories[identifier='Application%20Development%20Frameworks']"/>
     </features>
-    <features name="org.eclipse.gef.dot.user.feature.group" versionRange="[5.1.3.202209120200]">
+    <features name="org.eclipse.gef.dot.user.feature.group" versionRange="[5.1.3.202311221639]">
       <categories href="simrel.aggr#//@customCategories[identifier='Application%20Development%20Frameworks']"/>
     </features>
-    <features name="org.eclipse.gef.fx.sdk.feature.group" versionRange="[5.0.5.202209120200]">
+    <features name="org.eclipse.gef.fx.sdk.feature.group" versionRange="[5.0.5.202311221639]">
       <categories href="simrel.aggr#//@customCategories[identifier='Application%20Development%20Frameworks']"/>
     </features>
-    <features name="org.eclipse.gef.mvc.sdk.feature.group" versionRange="[5.2.3.202209120200]">
+    <features name="org.eclipse.gef.mvc.sdk.feature.group" versionRange="[5.2.3.202311221639]">
       <categories href="simrel.aggr#//@customCategories[identifier='Application%20Development%20Frameworks']"/>
     </features>
-    <features name="org.eclipse.gef.zest.sdk.feature.group" versionRange="[5.1.2.202209120200]">
+    <features name="org.eclipse.gef.zest.sdk.feature.group" versionRange="[5.1.2.202311221639]">
       <categories href="simrel.aggr#//@customCategories[identifier='Application%20Development%20Frameworks']"/>
     </features>
-    <features name="org.eclipse.gef.cloudio.sdk.feature.group" versionRange="[5.0.2.202209120200]">
+    <features name="org.eclipse.gef.cloudio.sdk.feature.group" versionRange="[5.0.2.202311221639]">
       <categories href="simrel.aggr#//@customCategories[identifier='Application%20Development%20Frameworks']"/>
     </features>
-    <features name="org.eclipse.gef.cloudio.user.feature.group" versionRange="[5.0.2.202209120200]">
+    <features name="org.eclipse.gef.cloudio.user.feature.group" versionRange="[5.0.2.202311221639]">
       <categories href="simrel.aggr#//@customCategories[identifier='Application%20Development%20Frameworks']"/>
     </features>
   </repositories>

--- a/gef.aggrcon
+++ b/gef.aggrcon
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="ASCII"?>
 <aggregator:Contribution xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:aggregator="http://www.eclipse.org/cbi/p2repo/2011/aggregator/1.1.0" label="GEF">
-  <repositories location="https://download.eclipse.org/tools/gef/classic/releases/3.18.0M2" description="GEF-Classic releases">
+  <repositories location="https://download.eclipse.org/tools/gef/classic/releases/3.18.0RC1" description="GEF-Classic releases">
     <features name="org.eclipse.gef.sdk.feature.group">
       <categories href="simrel.aggr#//@customCategories[identifier='Modeling']"/>
     </features>

--- a/gmp-gmf-runtime.aggrcon
+++ b/gmp-gmf-runtime.aggrcon
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="ASCII"?>
 <aggregator:Contribution xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:aggregator="http://www.eclipse.org/cbi/p2repo/2011/aggregator/1.1.0" label="GMF Runtime">
-  <repositories location="https://download.eclipse.org/modeling/gmp/gmf-runtime/updates/releases/R202309010720/" description="GMF Runtime 1.16.1">
+  <repositories location="https://download.eclipse.org/modeling/gmp/gmf-runtime/updates/milestones/S202311130907" description="GMF Runtime 1.16.2rc1">
     <features name="org.eclipse.gmf.feature.group">
       <categories href="simrel.aggr#//@customCategories[identifier='Modeling']"/>
     </features>

--- a/gmp-gmf-runtime.aggrcon
+++ b/gmp-gmf-runtime.aggrcon
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="ASCII"?>
 <aggregator:Contribution xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:aggregator="http://www.eclipse.org/cbi/p2repo/2011/aggregator/1.1.0" label="GMF Runtime">
-  <repositories location="https://download.eclipse.org/modeling/gmp/gmf-runtime/updates/milestones/S202311130907" description="GMF Runtime 1.16.2rc1">
+  <repositories location="https://download.eclipse.org/modeling/gmp/gmf-runtime/updates/releases/R202311130907/" description="GMF Runtime 1.16.2">
     <features name="org.eclipse.gmf.feature.group">
       <categories href="simrel.aggr#//@customCategories[identifier='Modeling']"/>
     </features>

--- a/linuxtools.aggrcon
+++ b/linuxtools.aggrcon
@@ -1,72 +1,72 @@
 <?xml version="1.0" encoding="ASCII"?>
 <aggregator:Contribution xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:aggregator="http://www.eclipse.org/cbi/p2repo/2011/aggregator/1.1.0" label="Linux Tools">
-  <repositories location="https://download.eclipse.org/linuxtools/update-2023-12-m3" description="Linux Tools Updates">
-    <features name="org.eclipse.linuxtools.cdt.libhover.devhelp.feature.feature.group" versionRange="[8.13.0.202311142319,8.13.1)">
+  <repositories location="https://download.eclipse.org/linuxtools/update-2023-12-rc1" description="Linux Tools Updates">
+    <features name="org.eclipse.linuxtools.cdt.libhover.devhelp.feature.feature.group" versionRange="[8.13.0.202311212015,8.13.1)">
       <categories href="simrel.aggr#//@customCategories[identifier='Linux%20Tools']"/>
     </features>
-    <features name="org.eclipse.linuxtools.cdt.libhover.feature.feature.group" versionRange="[8.13.0.202311142319,8.13.1)">
+    <features name="org.eclipse.linuxtools.cdt.libhover.feature.feature.group" versionRange="[8.13.0.202311212015,8.13.1)">
       <categories href="simrel.aggr#//@customCategories[identifier='Programming%20Languages']"/>
     </features>
-    <features name="org.eclipse.linuxtools.changelog.feature.group" versionRange="[8.13.0.202311142319,8.13.1)">
+    <features name="org.eclipse.linuxtools.changelog.feature.group" versionRange="[8.13.0.202311212015,8.13.1)">
       <categories href="simrel.aggr#//@customCategories[identifier='General%20Purpose%20Tools']"/>
     </features>
-    <features name="org.eclipse.linuxtools.gprof.feature.feature.group" versionRange="[8.13.0.202311142319,8.13.1)">
+    <features name="org.eclipse.linuxtools.gprof.feature.feature.group" versionRange="[8.13.0.202311212015,8.13.1)">
       <categories href="simrel.aggr#//@customCategories[identifier='Performance%2C%20Profiling%20and%20Tracing%20Tools']"/>
     </features>
-    <features name="org.eclipse.linuxtools.rpm.feature.group" versionRange="[8.13.0.202311142319,8.13.1)">
+    <features name="org.eclipse.linuxtools.rpm.feature.group" versionRange="[8.13.0.202311212015,8.13.1)">
       <categories href="simrel.aggr#//@customCategories[identifier='General%20Purpose%20Tools']"/>
     </features>
-    <features name="org.eclipse.linuxtools.systemtap.feature.group" versionRange="[8.13.0.202311142319,8.13.1)">
+    <features name="org.eclipse.linuxtools.systemtap.feature.group" versionRange="[8.13.0.202311212015,8.13.1)">
       <categories href="simrel.aggr#//@customCategories[identifier='Performance%2C%20Profiling%20and%20Tracing%20Tools']"/>
     </features>
-    <features name="org.eclipse.linuxtools.callgraph.feature.feature.group" versionRange="[8.13.0.202311142319,8.13.1)">
+    <features name="org.eclipse.linuxtools.callgraph.feature.feature.group" versionRange="[8.13.0.202311212015,8.13.1)">
       <categories href="simrel.aggr#//@customCategories[identifier='Programming%20Languages']"/>
     </features>
-    <features name="org.eclipse.linuxtools.valgrind.feature.group" versionRange="[8.13.0.202311142319,8.13.1)">
+    <features name="org.eclipse.linuxtools.valgrind.feature.group" versionRange="[8.13.0.202311212015,8.13.1)">
       <categories href="simrel.aggr#//@customCategories[identifier='Performance%2C%20Profiling%20and%20Tracing%20Tools']"/>
     </features>
-    <features name="org.eclipse.linuxtools.gcov.feature.group" versionRange="[8.13.0.202311142319,8.13.1)">
+    <features name="org.eclipse.linuxtools.gcov.feature.group" versionRange="[8.13.0.202311212015,8.13.1)">
       <categories href="simrel.aggr#//@customCategories[identifier='Linux%20Tools']"/>
     </features>
-    <features name="org.eclipse.linuxtools.perf.feature.feature.group" versionRange="[8.13.0.202311142319,8.13.1)">
+    <features name="org.eclipse.linuxtools.perf.feature.feature.group" versionRange="[8.13.0.202311212015,8.13.1)">
       <categories href="simrel.aggr#//@customCategories[identifier='Performance%2C%20Profiling%20and%20Tracing%20Tools']"/>
     </features>
-    <features name="org.eclipse.linuxtools.javadocs.feature.feature.group" versionRange="[8.13.0.202311142319,8.13.1)">
+    <features name="org.eclipse.linuxtools.javadocs.feature.feature.group" versionRange="[8.13.0.202311212015,8.13.1)">
       <categories href="simrel.aggr#//@customCategories[identifier='Programming%20Languages']"/>
     </features>
-    <features name="org.eclipse.linuxtools.man.feature.group" versionRange="[8.13.0.202311142319,8.13.1)">
+    <features name="org.eclipse.linuxtools.man.feature.group" versionRange="[8.13.0.202311212015,8.13.1)">
       <categories href="simrel.aggr#//@customCategories[identifier='General%20Purpose%20Tools']"/>
     </features>
-    <features name="org.eclipse.linuxtools.changelog.c.feature.group" versionRange="[8.13.0.202311142319,8.13.1)"/>
-    <features name="org.eclipse.linuxtools.changelog.java.feature.group" versionRange="[8.13.0.202311142319,8.13.1)"/>
-    <features name="org.eclipse.linuxtools.cdt.libhover.devhelp.feature.source.feature.group" versionRange="[8.13.0.202311142319,8.13.1)"/>
-    <features name="org.eclipse.linuxtools.cdt.libhover.feature.source.feature.group" versionRange="[8.13.0.202311142319,8.13.1)"/>
-    <features name="org.eclipse.linuxtools.changelog.source.feature.group" versionRange="[8.13.0.202311142319,8.13.1)"/>
-    <features name="org.eclipse.linuxtools.gprof.feature.source.feature.group" versionRange="[8.13.0.202311142319,8.13.1)"/>
-    <features name="org.eclipse.linuxtools.rpm.source.feature.group" versionRange="[8.13.0.202311142319,8.13.1)"/>
-    <features name="org.eclipse.linuxtools.systemtap.source.feature.group" versionRange="[8.13.0.202311142319,8.13.1)"/>
-    <features name="org.eclipse.linuxtools.callgraph.feature.source.feature.group" versionRange="[8.13.0.202311142319,8.13.1)"/>
-    <features name="org.eclipse.linuxtools.valgrind.source.feature.group" versionRange="[8.13.0.202311142319,8.13.1)"/>
-    <features name="org.eclipse.linuxtools.gcov.source.feature.group" versionRange="[8.13.0.202311142319,8.13.1)"/>
-    <features name="org.eclipse.linuxtools.perf.feature.source.feature.group" versionRange="[8.13.0.202311142319,8.13.1)"/>
-    <features name="org.eclipse.linuxtools.profiling.source.feature.group" versionRange="[8.13.0.202311142319,8.13.1)"/>
-    <features name="org.eclipse.linuxtools.dataviewers.feature.feature.group" versionRange="[8.13.0.202311142319,8.13.1)"/>
-    <features name="org.eclipse.linuxtools.dataviewers.feature.source.feature.group" versionRange="[8.13.0.202311142319,8.13.1)"/>
-    <features name="org.eclipse.linuxtools.man.source.feature.group" versionRange="[8.13.0.202311142319,8.13.1)"/>
+    <features name="org.eclipse.linuxtools.changelog.c.feature.group" versionRange="[8.13.0.202311212015,8.13.1)"/>
+    <features name="org.eclipse.linuxtools.changelog.java.feature.group" versionRange="[8.13.0.202311212015,8.13.1)"/>
+    <features name="org.eclipse.linuxtools.cdt.libhover.devhelp.feature.source.feature.group" versionRange="[8.13.0.202311212015,8.13.1)"/>
+    <features name="org.eclipse.linuxtools.cdt.libhover.feature.source.feature.group" versionRange="[8.13.0.202311212015,8.13.1)"/>
+    <features name="org.eclipse.linuxtools.changelog.source.feature.group" versionRange="[8.13.0.202311212015,8.13.1)"/>
+    <features name="org.eclipse.linuxtools.gprof.feature.source.feature.group" versionRange="[8.13.0.202311212015,8.13.1)"/>
+    <features name="org.eclipse.linuxtools.rpm.source.feature.group" versionRange="[8.13.0.202311212015,8.13.1)"/>
+    <features name="org.eclipse.linuxtools.systemtap.source.feature.group" versionRange="[8.13.0.202311212015,8.13.1)"/>
+    <features name="org.eclipse.linuxtools.callgraph.feature.source.feature.group" versionRange="[8.13.0.202311212015,8.13.1)"/>
+    <features name="org.eclipse.linuxtools.valgrind.source.feature.group" versionRange="[8.13.0.202311212015,8.13.1)"/>
+    <features name="org.eclipse.linuxtools.gcov.source.feature.group" versionRange="[8.13.0.202311212015,8.13.1)"/>
+    <features name="org.eclipse.linuxtools.perf.feature.source.feature.group" versionRange="[8.13.0.202311212015,8.13.1)"/>
+    <features name="org.eclipse.linuxtools.profiling.source.feature.group" versionRange="[8.13.0.202311212015,8.13.1)"/>
+    <features name="org.eclipse.linuxtools.dataviewers.feature.feature.group" versionRange="[8.13.0.202311212015,8.13.1)"/>
+    <features name="org.eclipse.linuxtools.dataviewers.feature.source.feature.group" versionRange="[8.13.0.202311212015,8.13.1)"/>
+    <features name="org.eclipse.linuxtools.man.source.feature.group" versionRange="[8.13.0.202311212015,8.13.1)"/>
   </repositories>
-  <repositories location="https://download.eclipse.org/linuxtools/update-2023-12-docker-m3" description="Linux Tools Docker Support Updates">
-    <features name="org.eclipse.linuxtools.docker.feature.feature.group" versionRange="[5.13.0.202311142319,5.13.1)">
+  <repositories location="https://download.eclipse.org/linuxtools/update-2023-12-docker-rc1" description="Linux Tools Docker Support Updates">
+    <features name="org.eclipse.linuxtools.docker.feature.feature.group" versionRange="[5.13.0.202311212015,5.13.1)">
       <categories href="simrel.aggr#//@customCategories[identifier='General%20Purpose%20Tools']"/>
     </features>
-    <features name="org.eclipse.linuxtools.vagrant.feature.feature.group" versionRange="[5.13.0.202311142319,5.13.1)">
+    <features name="org.eclipse.linuxtools.vagrant.feature.feature.group" versionRange="[5.13.0.202311212015,5.13.1)">
       <categories href="simrel.aggr#//@customCategories[identifier='General%20Purpose%20Tools']"/>
     </features>
-    <features name="org.eclipse.linuxtools.jdt.docker.launcher.feature.feature.group" versionRange="[5.13.0.202311142319,5.13.1)">
+    <features name="org.eclipse.linuxtools.jdt.docker.launcher.feature.feature.group" versionRange="[5.13.0.202311212015,5.13.1)">
       <categories href="simrel.aggr#//@customCategories[identifier='Programming%20Languages']"/>
     </features>
-    <features name="org.eclipse.linuxtools.docker.feature.source.feature.group" versionRange="[5.13.0.202311142319,5.13.1)"/>
-    <features name="org.eclipse.linuxtools.vagrant.feature.source.feature.group" versionRange="[5.13.0.202311142319,5.13.1)"/>
-    <features name="org.eclipse.linuxtools.jdt.docker.launcher.feature.source.feature.group" versionRange="[5.13.0.202311142319,5.13.1)"/>
+    <features name="org.eclipse.linuxtools.docker.feature.source.feature.group" versionRange="[5.13.0.202311212015,5.13.1)"/>
+    <features name="org.eclipse.linuxtools.vagrant.feature.source.feature.group" versionRange="[5.13.0.202311212015,5.13.1)"/>
+    <features name="org.eclipse.linuxtools.jdt.docker.launcher.feature.source.feature.group" versionRange="[5.13.0.202311212015,5.13.1)"/>
   </repositories>
   <contacts href="simrel.aggr#//@contacts[email='jjohnstn@redhat.com']"/>
   <contacts href="simrel.aggr#//@contacts[email='akurtako@redhat.com']"/>

--- a/lsp4e.aggrcon
+++ b/lsp4e.aggrcon
@@ -1,17 +1,17 @@
 <?xml version="1.0" encoding="ASCII"?>
 <aggregator:Contribution xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:aggregator="http://www.eclipse.org/cbi/p2repo/2011/aggregator/1.1.0" label="LSP4E">
-  <repositories location="https://download.eclipse.org/lsp4e/releases/0.24.4/" description="LSP4E">
+  <repositories location="https://download.eclipse.org/lsp4e/releases/0.24.5/" description="LSP4E">
     <features name="org.eclipse.lsp4e" versionRange="[0.18.1.202311121506]">
       <categories href="simrel.aggr#//@customCategories[identifier='General%20Purpose%20Tools']"/>
     </features>
-    <features name="org.eclipse.lsp4e.debug" versionRange="[0.15.5.202310060649]">
+    <features name="org.eclipse.lsp4e.debug" versionRange="[0.15.6.202311221020]">
       <categories href="simrel.aggr#//@customCategories[identifier='General%20Purpose%20Tools']"/>
     </features>
     <features name="org.eclipse.lsp4e.jdt" versionRange="[0.11.0.202301312314]">
       <categories href="simrel.aggr#//@customCategories[identifier='General%20Purpose%20Tools']"/>
     </features>
     <features name="org.eclipse.lsp4e.source" versionRange="[0.18.1.202311121506]"/>
-    <features name="org.eclipse.lsp4e.debug.source" versionRange="[0.15.5.202310060649]"/>
+    <features name="org.eclipse.lsp4e.debug.source" versionRange="[0.15.6.202311221020]"/>
     <features name="org.eclipse.lsp4e.jdt.source" versionRange="[0.11.0.202301312314]"/>
   </repositories>
   <contacts href="simrel.aggr#//@contacts[email='mistria@redhat.com']"/>

--- a/m2t-acceleo.aggrcon
+++ b/m2t-acceleo.aggrcon
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="ASCII"?>
 <aggregator:Contribution xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:aggregator="http://www.eclipse.org/cbi/p2repo/2011/aggregator/1.1.0" label="M2T ACCELEO">
-  <repositories location="https://download.eclipse.org/acceleo/updates/milestones/3.7/S202304041222/" description="Acceleo">
+  <repositories location="https://download.eclipse.org/acceleo/updates/milestones/3.7/S202311201319" description="Acceleo">
     <features name="org.eclipse.acceleo.feature.group" versionRange="[3.7.0,3.8.0)">
       <categories href="simrel.aggr#//@customCategories[identifier='Modeling']"/>
     </features>

--- a/mat.aggrcon
+++ b/mat.aggrcon
@@ -1,15 +1,15 @@
 <?xml version="1.0" encoding="ASCII"?>
 <aggregator:Contribution xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:aggregator="http://www.eclipse.org/cbi/p2repo/2011/aggregator/1.1.0" label="Memory Analyzer (MAT)">
-  <repositories location="https://download.eclipse.org/mat/2023-12/M3/update-site/" description="Memory Analyzer Updates">
+  <repositories location="https://download.eclipse.org/mat/2023-12/RC1/update-site/" description="Memory Analyzer Updates">
     <bundles name="org.eclipse.birt.chart.device.extension" versionRange="[4.12.0.v202211281949]"/>
     <bundles name="org.eclipse.birt.chart.engine" versionRange="[4.12.0.v202211281949]"/>
     <bundles name="org.eclipse.birt.chart.device.swt" versionRange="[4.12.0.v202211281949]"/>
     <bundles name="org.eclipse.birt.chart.engine.extension" versionRange="[4.12.0.v202211281949]"/>
     <bundles name="org.eclipse.birt.core" versionRange="[4.12.0.v202211281949]"/>
-    <features name="org.eclipse.mat.feature.feature.group" versionRange="[1.15.0.202311131616]">
+    <features name="org.eclipse.mat.feature.feature.group" versionRange="[1.15.0.202311170814]">
       <categories href="simrel.aggr#//@customCategories[identifier='Performance%2C%20Profiling%20and%20Tracing%20Tools']"/>
     </features>
-    <features name="org.eclipse.mat.chart.feature.feature.group" versionRange="[1.15.0.202311131616]">
+    <features name="org.eclipse.mat.chart.feature.feature.group" versionRange="[1.15.0.202311170814]">
       <categories href="simrel.aggr#//@customCategories[identifier='Performance%2C%20Profiling%20and%20Tracing%20Tools']"/>
     </features>
   </repositories>

--- a/modisco.aggrcon
+++ b/modisco.aggrcon
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="ASCII"?>
 <aggregator:Contribution xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:aggregator="http://www.eclipse.org/cbi/p2repo/2011/aggregator/1.1.0" label="MoDisco for 2023-12">
-  <repositories location="https://download.eclipse.org/modeling/mdt/modisco/updates/milestones/1.5.3/S202311201217" description="MoDisco">
-    <features name="org.eclipse.modisco.sdk.feature.feature.group" versionRange="[1.5.2,1.6.0)">
+  <repositories location="https://download.eclipse.org/modeling/mdt/modisco/updates/releases/1.5.3" description="MoDisco">
+    <features name="org.eclipse.modisco.sdk.feature.feature.group" versionRange="[1.5.3,1.6.0)">
       <categories href="simrel.aggr#//@customCategories[identifier='Modeling']"/>
     </features>
-    <features name="org.eclipse.modisco.sdk.feature.source.feature.group" versionRange="[1.5.2,1.6.0)">
+    <features name="org.eclipse.modisco.sdk.feature.source.feature.group" versionRange="[1.5.3,1.6.0)">
       <categories href="simrel.aggr#//@customCategories[identifier='Modeling']"/>
     </features>
   </repositories>

--- a/modisco.aggrcon
+++ b/modisco.aggrcon
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="ASCII"?>
 <aggregator:Contribution xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:aggregator="http://www.eclipse.org/cbi/p2repo/2011/aggregator/1.1.0" label="MoDisco for 2023-12">
-  <repositories location="https://download.eclipse.org/modeling/mdt/modisco/updates/releases/1.5.2" description="MoDisco">
+  <repositories location="https://download.eclipse.org/modeling/mdt/modisco/updates/milestones/1.5.3/S202311201217" description="MoDisco">
     <features name="org.eclipse.modisco.sdk.feature.feature.group" versionRange="[1.5.2,1.6.0)">
       <categories href="simrel.aggr#//@customCategories[identifier='Modeling']"/>
     </features>

--- a/mylyn.aggrcon
+++ b/mylyn.aggrcon
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="ASCII"?>
 <aggregator:Contribution xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:aggregator="http://www.eclipse.org/cbi/p2repo/2011/aggregator/1.1.0" label="Mylyn">
-  <repositories location="https://download.eclipse.org/mylyn/updates/milestone/S202311141700" description="Mylyn 4.1.0">
+  <repositories location="https://download.eclipse.org/mylyn/updates/milestone/S202311221551" description="Mylyn 4.1.0">
     <features name="org.eclipse.mylyn.bugzilla.feature.feature.group" versionRange="[4.1.0.v20231009-0014]">
       <categories href="simrel.aggr#//@customCategories[identifier='Collaboration']"/>
     </features>

--- a/ocl.aggrcon
+++ b/ocl.aggrcon
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="ASCII"?>
 <aggregator:Contribution xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:aggregator="http://www.eclipse.org/cbi/p2repo/2011/aggregator/1.1.0" label="OCL for 2023-12">
-  <repositories location="https://download.eclipse.org/modeling/mdt/ocl/updates/milestones/6.19.0/S202311151234" description="OCL">
+  <repositories location="https://download.eclipse.org/modeling/mdt/ocl/updates/milestones/6.19.0/S202311201059" description="OCL">
     <features name="org.eclipse.ocl.all.sdk.feature.group" versionRange="[5.19.0,5.20.0)">
       <categories href="simrel.aggr#//@customCategories[identifier='Modeling']"/>
       <categories href="simrel.aggr#//@customCategories[identifier='General%20Purpose%20Tools']"/>

--- a/oomph.aggrcon
+++ b/oomph.aggrcon
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <aggregator:Contribution xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:aggregator="http://www.eclipse.org/cbi/p2repo/2011/aggregator/1.1.0" label="Oomph">
-  <repositories location="https://download.eclipse.org/oomph/drops/milestone/S20231115-091438-1.31.0-M3" description="Oomph 1.31">
+  <repositories location="https://download.eclipse.org/oomph/drops/milestone/S20231122-090804-1.31.0-RC1" description="Oomph 1.31">
     <features name="org.eclipse.oomph.setup.sdk.feature.group">
       <categories href="simrel.aggr#//@customCategories[identifier='General%20Purpose%20Tools']"/>
     </features>

--- a/passage.aggrcon
+++ b/passage.aggrcon
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="ASCII"?>
-<aggregator:Contribution xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:aggregator="http://www.eclipse.org/cbi/p2repo/2011/aggregator/1.1.0" label="Eclipse Passage">
-  <repositories location="https://download.eclipse.org/passage/updates/milestone/2.10.0-M3/ldc/" description="Eclipse Passage LDC 2.10.0 M2">
+<aggregator:Contribution xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:aggregator="http://www.eclipse.org/cbi/p2repo/2011/aggregator/1.1.0" label="Passage">
+  <repositories location="https://download.eclipse.org/passage/updates/milestone/2.10.0-RC1/ldc/" description="Eclipse Passage LDC 2.10.0 M2">
     <features name="org.eclipse.passage.ldc.feature.feature.group" versionRange="[2.10.0.v20231115-0933]">
       <categories href="simrel.aggr#//@customCategories[identifier='License%20Management']"/>
     </features>

--- a/ptp.aggrcon
+++ b/ptp.aggrcon
@@ -1,33 +1,34 @@
 <?xml version="1.0" encoding="ASCII"?>
 <aggregator:Contribution xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:aggregator="http://www.eclipse.org/cbi/p2repo/2011/aggregator/1.1.0" label="PTP">
   <repositories location="https://download.eclipse.org/tools/ptp/builds/9.4/2021-09" description="PTP updates">
-    <features name="org.eclipse.ptp.feature.group" versionRange="9.4.1">
+    <features name="org.eclipse.ptp.feature.group" versionRange="9.4.1" enabled="false">
       <categories href="simrel.aggr#//@customCategories[identifier='General%20Purpose%20Tools']"/>
     </features>
-    <features name="org.eclipse.ptp.fortran.feature.group" versionRange="9.4.1">
+    <features name="org.eclipse.ptp.fortran.feature.group" versionRange="9.4.1" enabled="false">
       <categories href="simrel.aggr#//@customCategories[identifier='General%20Purpose%20Tools']"/>
     </features>
-    <features name="org.eclipse.ptp.rm.jaxb.contrib.feature.group" versionRange="9.4.1">
+    <features name="org.eclipse.ptp.rm.jaxb.contrib.feature.group" versionRange="9.4.1" enabled="false">
       <categories href="simrel.aggr#//@customCategories[identifier='General%20Purpose%20Tools']"/>
     </features>
-    <features name="org.eclipse.ptp.etfw.tau.feature.group" versionRange="9.4.1">
+    <features name="org.eclipse.ptp.etfw.tau.feature.group" versionRange="9.4.1" enabled="false">
       <categories href="simrel.aggr#//@customCategories[identifier='General%20Purpose%20Tools']"/>
     </features>
-    <features name="org.eclipse.photran.feature.group" versionRange="9.4.1">
+    <features name="org.eclipse.photran.feature.group" versionRange="9.4.1" enabled="false">
       <categories href="simrel.aggr#//@customCategories[identifier='Programming%20Languages']"/>
     </features>
-    <features name="org.eclipse.photran.intel.feature.group" versionRange="9.4.1">
+    <features name="org.eclipse.photran.intel.feature.group" versionRange="9.4.1" enabled="false">
       <categories href="simrel.aggr#//@customCategories[identifier='Programming%20Languages']"/>
     </features>
-    <features name="org.eclipse.photran.xlf.feature.group" versionRange="9.4.1">
+    <features name="org.eclipse.photran.xlf.feature.group" versionRange="9.4.1" enabled="false">
       <categories href="simrel.aggr#//@customCategories[identifier='Programming%20Languages']"/>
     </features>
-    <features name="org.eclipse.ptp.debug.sdm.feature.group" versionRange="9.4.1">
+    <features name="org.eclipse.ptp.debug.sdm.feature.group" versionRange="9.4.1" enabled="false">
       <categories href="simrel.aggr#//@customCategories[identifier='General%20Purpose%20Tools']"/>
     </features>
-    <features name="org.eclipse.ptp.etfw.feedback.perfsuite.feature.group" versionRange="9.4.1">
+    <features name="org.eclipse.ptp.etfw.feedback.perfsuite.feature.group" versionRange="9.4.1" enabled="false">
       <categories href="simrel.aggr#//@customCategories[identifier='General%20Purpose%20Tools']"/>
     </features>
+    <features name="org.eclipse.ptp.rdt.sync.feature.group"/>
   </repositories>
   <contacts href="simrel.aggr#//@contacts[email='g.watson@computer.org']"/>
 </aggregator:Contribution>

--- a/qvtd.aggrcon
+++ b/qvtd.aggrcon
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="ASCII"?>
 <aggregator:Contribution xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:aggregator="http://www.eclipse.org/cbi/p2repo/2011/aggregator/1.1.0" label="QVT Declarative for 2023-12">
-  <repositories location="https://download.eclipse.org/mmt/qvtd/updates/milestones/0.30.0/S202311151312" description="QVT Declarative">
+  <repositories location="https://download.eclipse.org/mmt/qvtd/updates/milestones/0.30.0/S202311211222" description="QVT Declarative">
     <features name="org.eclipse.qvtd.master.feature.group" versionRange="[0.30.0,1.0.0)">
       <categories href="simrel.aggr#//@customCategories[identifier='Modeling']"/>
     </features>

--- a/qvto.aggrcon
+++ b/qvto.aggrcon
@@ -1,16 +1,16 @@
 <?xml version="1.0" encoding="ASCII"?>
 <aggregator:Contribution xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:aggregator="http://www.eclipse.org/cbi/p2repo/2011/aggregator/1.1.0" label="QVT Operational for 2023-12">
-  <repositories location="https://download.eclipse.org/mmt/qvto/updates/milestones/3.10.8/S202311201150" description="QVT Operational 3.10.8 release">
-    <features name="org.eclipse.m2m.qvt.oml.sdk.feature.group" versionRange="[3.10.7,3.11.0)">
+  <repositories location="https://download.eclipse.org/mmt/qvto/updates/releases/3.10.8" description="QVT Operational 3.10.8 release">
+    <features name="org.eclipse.m2m.qvt.oml.sdk.feature.group" versionRange="[3.10.8,3.11.0)">
       <categories href="simrel.aggr#//@customCategories[identifier='Modeling']"/>
     </features>
-    <features name="org.eclipse.m2m.qvt.oml.sdk.source.feature.group" versionRange="[3.10.7,3.11.0)">
+    <features name="org.eclipse.m2m.qvt.oml.sdk.source.feature.group" versionRange="[3.10.8,3.11.0)">
       <categories href="simrel.aggr#//@customCategories[identifier='Modeling']"/>
     </features>
-    <features name="org.eclipse.m2m.qvt.oml.tools.coverage.source.feature.group" versionRange="[1.6.7,1.7.0)">
+    <features name="org.eclipse.m2m.qvt.oml.tools.coverage.source.feature.group" versionRange="[1.6.8,1.7.0)">
       <categories href="simrel.aggr#//@customCategories[identifier='Modeling']"/>
     </features>
-    <features name="org.eclipse.m2m.qvt.oml.tools.coverage.feature.group" versionRange="[1.6.7,1.7.0)">
+    <features name="org.eclipse.m2m.qvt.oml.tools.coverage.feature.group" versionRange="[1.6.8,1.7.0)">
       <categories href="simrel.aggr#//@customCategories[identifier='Modeling']"/>
     </features>
   </repositories>

--- a/qvto.aggrcon
+++ b/qvto.aggrcon
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="ASCII"?>
 <aggregator:Contribution xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:aggregator="http://www.eclipse.org/cbi/p2repo/2011/aggregator/1.1.0" label="QVT Operational for 2023-12">
-  <repositories location="https://download.eclipse.org/mmt/qvto/updates/milestones/3.10.8/S202311140611" description="QVT Operational 3.10.8 release">
+  <repositories location="https://download.eclipse.org/mmt/qvto/updates/milestones/3.10.8/S202311201150" description="QVT Operational 3.10.8 release">
     <features name="org.eclipse.m2m.qvt.oml.sdk.feature.group" versionRange="[3.10.7,3.11.0)">
       <categories href="simrel.aggr#//@customCategories[identifier='Modeling']"/>
     </features>

--- a/rap-tools.aggrcon
+++ b/rap-tools.aggrcon
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="ASCII"?>
 <aggregator:Contribution xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:aggregator="http://www.eclipse.org/cbi/p2repo/2011/aggregator/1.1.0" label="RAP Tools">
-  <repositories location="https://download.eclipse.org/rt/rap/tools/3.27/M3-20231115-1312/" description="RAP 3.27 Tools Repository">
+  <repositories location="https://download.eclipse.org/rt/rap/tools/3.27/RC1-20231122-0037/" description="RAP 3.27 Tools Repository">
     <features name="org.eclipse.rap.tools.feature.feature.group" versionRange="[3.27.0,3.28.0)">
       <categories href="simrel.aggr#//@customCategories[identifier='Web%2C%20XML%2C%20Java%20EE%20and%20OSGi%20Enterprise%20Development']"/>
     </features>

--- a/rap.aggrcon
+++ b/rap.aggrcon
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="ASCII"?>
 <aggregator:Contribution xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:aggregator="http://www.eclipse.org/cbi/p2repo/2011/aggregator/1.1.0" label="RAP Runtime">
-  <repositories location="https://download.eclipse.org/rt/rap/3.27/M3-20231115-1312/" description="RAP 3.27 Runtime Repository">
+  <repositories location="https://download.eclipse.org/rt/rap/3.27/RC1-20231122-0036/" description="RAP 3.27 Runtime Repository">
     <features name="org.eclipse.rap.feature.feature.group" versionRange="[3.27.0,3.28.0)">
       <categories href="simrel.aggr#//@customCategories[identifier='EclipseRT%20Target%20Platform%20Components']"/>
     </features>

--- a/rcptt.aggrcon
+++ b/rcptt.aggrcon
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="ASCII"?>
-<aggregator:Contribution xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:aggregator="http://www.eclipse.org/cbi/p2repo/2011/aggregator/1.1.0" label="RCPTT">
+<aggregator:Contribution xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:aggregator="http://www.eclipse.org/cbi/p2repo/2011/aggregator/1.1.0" enabled="false" label="RCPTT">
   <repositories location="https://download.eclipse.org/rcptt/release/2.5.4/repository/">
     <features name="org.eclipse.rcptt.platform.feature.group" versionRange="2.5.4">
       <categories href="simrel.aggr#//@customCategories[identifier='Testing']"/>

--- a/scout.aggrcon
+++ b/scout.aggrcon
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="ASCII"?>
 <aggregator:Contribution xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:aggregator="http://www.eclipse.org/cbi/p2repo/2011/aggregator/1.1.0" description="Eclipse Scout is a framework to develop Java based business applications.&#xA;The HTML5 front-end of Scout applications comes with multi-device support and is based on HTML5/CSS3/JavaScript. This package includes a SDK, useful developer tools and source code." label="Scout">
-  <repositories location="https://download.eclipse.org/scout/releases/13.0/25/" description="Scout SDK">
-    <features description="Eclipse Scout SDK" name="org.eclipse.scout.sdk-feature.feature.group" versionRange="13.0.25">
+  <repositories location="https://download.eclipse.org/scout/releases/13.0/26/" description="Scout SDK">
+    <features description="Eclipse Scout SDK" name="org.eclipse.scout.sdk-feature.feature.group" versionRange="13.0.26">
       <categories href="simrel.aggr#//@customCategories[identifier='Application%20Development%20Frameworks']"/>
     </features>
   </repositories>

--- a/simrel.aggr
+++ b/simrel.aggr
@@ -1,18 +1,6 @@
 <?xml version="1.0" encoding="ASCII"?>
 <aggregator:Aggregation xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:aggregator="http://www.eclipse.org/cbi/p2repo/2011/aggregator/1.1.0" description="Aggregation files used for Simultaneous Release (quarterly &quot;release train&quot;)." buildmaster="//@contacts[email='ed.merks@gmail.com']" buildmasterBackup="//@contacts[email='frederic.gurr@eclipse.org']" label="2023-12" buildRoot="buildresults" packedStrategy="UNPACK_AS_SIBLING" sendmail="true" type="I" allowLegacySites="false" includeSources="true">
   <validationSets label="main">
-    <contributions label="Orbit-CVS-Legacy-To-Be-Deleted">
-      <repositories location="https://download.eclipse.org/oomph/simrel-extras/release/1.1.0">
-        <bundles name="org.w3c.css.sac" versionRange="[1.3.1.v200903091627]"/>
-        <bundles name="org.w3c.css.sac.source" versionRange="[1.3.1.v200903091627]"/>
-        <bundles name="org.w3c.dom.events" versionRange="[3.0.0.draft20060413_v201105210656]"/>
-        <bundles name="org.w3c.dom.events.source" versionRange="[3.0.0.draft20060413_v201105210656]"/>
-        <bundles name="org.w3c.dom.smil" versionRange="[1.0.1.v200903091627]"/>
-        <bundles name="org.w3c.dom.smil.source" versionRange="[1.0.1.v200903091627]"/>
-        <bundles name="org.w3c.dom.svg" versionRange="[1.1.0.v201011041433]"/>
-        <bundles name="org.w3c.dom.svg.source" versionRange="[1.1.0.v201011041433]"/>
-      </repositories>
-    </contributions>
     <contributions href="ep.aggrcon#/"/>
     <contributions href="emf-emf.aggrcon#/"/>
     <contributions href="ecf.aggrcon#/"/>

--- a/simrel.aggr
+++ b/simrel.aggr
@@ -133,7 +133,6 @@
     <features href="egit.aggrcon#//@repositories.0/@features.10"/>
     <features href="emf-cdo.aggrcon#//@repositories.0/@features.0"/>
     <features href="emf-cdo.aggrcon#//@repositories.0/@features.2"/>
-    <features href="ecf.aggrcon#//@repositories.0/@features.2"/>
   </customCategories>
   <customCategories identifier="Database Development" label="Database Development" description="Tools to define and access a wide variety of databases.">
     <features href="dtp.aggrcon#//@repositories.0/@features.0"/>
@@ -188,7 +187,6 @@
     <features href="emf-cdo.aggrcon#//@repositories.0/@features.0"/>
     <features href="emf-cdo.aggrcon#//@repositories.0/@features.1"/>
     <features href="emf-cdo.aggrcon#//@repositories.0/@features.2"/>
-    <features href="ecf.aggrcon#//@repositories.0/@features.2"/>
   </customCategories>
   <customCategories identifier="General Purpose Tools" label="General Purpose Tools" description="Tools that can be used by a wide variety of developers.">
     <features href="ep.aggrcon#//@repositories.0/@features.2"/>

--- a/simrel.aggran
+++ b/simrel.aggran
@@ -6,15 +6,12 @@
     releaseDate="2023-12-06"
     exclusion="tooling.*|.*\.source|.*\.source\.feature\.group|.*\.feature\.jar"
     aggregation="simrel.aggr#/">
-  <levels>65</levels>
+  <levels>62</levels>
   <levels>50</levels>
   <levels>30</levels>
   <levels>21</levels>
   <levels>7</levels>
   <levels>4</levels>
-  <contribution
-      label="a-Orbit-CVS-Legacy-To-Be-Deleted"
-      contribution="simrel.aggr#//@validationSets[label='main']/@contributions[label='Orbit-CVS-Legacy-To-Be-Deleted']"/>
   <contribution
       label="a.jre"
       dominant="true"
@@ -28,15 +25,9 @@
         version="https://projects.eclipse.org/projects/rt.jetty/releases/12.0"
         releaseDate="2023-07-20">
       <repository
-          uri="https://github.com/eclipse/jetty.alpn.api"/>
+          uri="https://github.com/jetty/jetty.project"/>
       <repository
-          uri="https://github.com/eclipse/jetty.docker"/>
-      <repository
-          uri="https://github.com/eclipse/jetty.parent"/>
-      <repository
-          uri="https://github.com/eclipse/jetty.project"/>
-      <repository
-          uri="https://github.com/eclipse/jetty.toolchain"/>
+          uri="https://github.com/jetty/jetty.toolchain"/>
     </project>
   </contribution>
   <contribution
@@ -49,8 +40,8 @@
     <project
         name="Eclipse Nebula - Supplemental Widgets for SWT"
         site="https://projects.eclipse.org/projects/technology.nebula"
-        version="https://projects.eclipse.org/projects/technology.nebula/releases/3.1"
-        releaseDate="2023-06-30">
+        version="https://projects.eclipse.org/projects/technology.nebula/releases/3.0.0"
+        releaseDate="2023-03-07">
       <repository
           uri="https://github.com/eclipse/nebula"/>
     </project>
@@ -83,8 +74,8 @@
     <project
         name="Eclipse Project"
         site="https://projects.eclipse.org/projects/eclipse"
-        version="https://projects.eclipse.org/projects/eclipse/releases/4.28.0"
-        releaseDate="2023-06-14">
+        version="https://projects.eclipse.org/projects/eclipse/releases/4.30.0"
+        releaseDate="2023-12-06">
       <subproject
           name="Eclipse Equinox"
           site="https://projects.eclipse.org/projects/eclipse.equinox">
@@ -92,10 +83,6 @@
             uri="https://github.com/eclipse-equinox/equinox"/>
         <repository
             uri="https://github.com/eclipse-equinox/equinox.binaries"/>
-        <repository
-            uri="https://github.com/eclipse-equinox/equinox.bundles"/>
-        <repository
-            uri="https://github.com/eclipse-equinox/equinox.framework"/>
         <repository
             uri="https://github.com/eclipse-equinox/p2"/>
       </subproject>
@@ -114,18 +101,10 @@
             uri="https://github.com/eclipse-jdt/eclipse.jdt.ui"/>
       </subproject>
       <subproject
-          name="Eclipse JDT LS"
-          site="https://projects.eclipse.org/projects/eclipse.jdt.ls">
-        <repository
-            uri="https://github.com/eclipse-jdtls/eclipse.jdt.ls"/>
-      </subproject>
-      <subproject
           name="Eclipse PDE"
           site="https://projects.eclipse.org/projects/eclipse.pde">
         <repository
             uri="https://github.com/eclipse-pde/eclipse.pde"/>
-        <repository
-            uri="https://github.com/eclipse-pde/eclipse.pde.build"/>
       </subproject>
       <subproject
           name="Eclipse Platform"
@@ -133,37 +112,15 @@
         <repository
             uri="https://github.com/eclipse-platform/eclipse.platform"/>
         <repository
-            uri="https://github.com/eclipse-platform/eclipse.platform.common"/>
-        <repository
-            uri="https://github.com/eclipse-platform/eclipse.platform.debug"/>
-        <repository
             uri="https://github.com/eclipse-platform/eclipse.platform.images"/>
         <repository
-            uri="https://github.com/eclipse-platform/eclipse.platform.releng"/>
-        <repository
             uri="https://github.com/eclipse-platform/eclipse.platform.releng.aggregator"/>
-        <repository
-            uri="https://github.com/eclipse-platform/eclipse.platform.releng.buildtools"/>
-        <repository
-            uri="https://github.com/eclipse-platform/eclipse.platform.resources"/>
-        <repository
-            uri="https://github.com/eclipse-platform/eclipse.platform.runtime"/>
         <repository
             uri="https://github.com/eclipse-platform/eclipse.platform.swt"/>
         <repository
             uri="https://github.com/eclipse-platform/eclipse.platform.swt.binaries"/>
         <repository
-            uri="https://github.com/eclipse-platform/eclipse.platform.team"/>
-        <repository
-            uri="https://github.com/eclipse-platform/eclipse.platform.text"/>
-        <repository
-            uri="https://github.com/eclipse-platform/eclipse.platform.ua"/>
-        <repository
             uri="https://github.com/eclipse-platform/eclipse.platform.ui"/>
-        <repository
-            uri="https://github.com/eclipse-platform/eclipse.platform.ui.tools"/>
-        <repository
-            uri="https://github.com/eclipse-platform/ui-best-practices"/>
       </subproject>
     </project>
   </contribution>
@@ -193,8 +150,6 @@
       <repository
           uri="https://github.com/eclipse-m2e/m2e-wtp"/>
       <repository
-          uri="https://github.com/eclipse-m2e/m2e-wtp-jpa"/>
-      <repository
           uri="https://github.com/eclipse-m2e/org.eclipse.m2e.workspace"/>
     </project>
   </contribution>
@@ -217,7 +172,7 @@
     <project
         name="Eclipse Graphical Editing Framework (GEF)"
         site="https://projects.eclipse.org/projects/tools.gef"
-        version="https://projects.eclipse.org/projects/tools.gef/releases/3.17.0-2023-09-5.4.0"
+        version="https://projects.eclipse.org/projects/tools.gef/releases/gef-classic-3.17.0-2023-09"
         releaseDate="2023-09-13">
       <repository
           uri="https://github.com/eclipse/gef"/>
@@ -234,12 +189,6 @@
         releaseDate="2023-03-08">
       <repository
           uri="https://github.com/eclipse-emf-compare/emf-compare"/>
-      <repository
-          uri="https://github.com/eclipse-emf-compare/emf-compare-acceptance"/>
-      <repository
-          uri="https://github.com/eclipse-emf-compare/emf-compare-cli"/>
-      <repository
-          uri="https://github.com/eclipse-emf-compare/emf-compare-releng"/>
     </project>
   </contribution>
   <contribution
@@ -264,8 +213,6 @@
         releaseDate="2023-06-26">
       <repository
           uri="https://git.eclipse.org/r/mmt/org.eclipse.atl"/>
-      <repository
-          uri="https://git.eclipse.org/r/mmt/org.eclipse.atl.tcs"/>
     </project>
   </contribution>
   <contribution
@@ -286,8 +233,8 @@
     <project
         name="Eclipse Modeling Workflow Engine"
         site="https://projects.eclipse.org/projects/modeling.emf.mwe"
-        version="https://projects.eclipse.org/projects/modeling.emf.mwe/releases/2.15.0"
-        releaseDate="2023-08-27">
+        version="https://projects.eclipse.org/projects/modeling.emf.mwe/releases/2.16.0"
+        releaseDate="2023-11-26">
       <repository
           uri="https://github.com/eclipse/mwe"/>
     </project>
@@ -310,31 +257,19 @@
     <project
         name="Eclipse Web Tools Platform Project"
         site="https://projects.eclipse.org/projects/webtools"
-        version="https://projects.eclipse.org/projects/webtools/releases/3.31"
-        releaseDate="2023-09-13">
+        version="https://projects.eclipse.org/projects/webtools/releases/3.32"
+        releaseDate="2023-12-06">
       <subproject
           name="Web Tools Common"
           site="https://projects.eclipse.org/projects/webtools.common">
         <repository
             uri="https://git.eclipse.org/r/webtools-common/webtools.common"/>
-        <repository
-            uri="https://git.eclipse.org/r/webtools-common/webtools.common.fproj"/>
-        <repository
-            uri="https://git.eclipse.org/r/webtools-common/webtools.common.snippets"/>
-        <repository
-            uri="https://git.eclipse.org/r/webtools-common/webtools.common.tests"/>
       </subproject>
       <subproject
           name="Eclipse Dali Java Persistence Tools"
           site="https://projects.eclipse.org/projects/webtools.dali">
         <repository
             uri="https://git.eclipse.org/r/dali/webtools.dali"/>
-      </subproject>
-      <subproject
-          name="Java EE Module Configuration Editors"
-          site="https://projects.eclipse.org/projects/webtools.java-ee-config">
-        <repository
-            uri="https://git.eclipse.org/r/webtools/org.eclipse.webtools.java-ee-config"/>
       </subproject>
       <subproject
           name="WTP Java EE Tools"
@@ -353,58 +288,24 @@
           site="https://projects.eclipse.org/projects/webtools.jsf">
         <repository
             uri="https://git.eclipse.org/r/jsf/webtools.jsf"/>
-        <repository
-            uri="https://git.eclipse.org/r/jsf/webtools.jsf.docs"/>
-        <repository
-            uri="https://git.eclipse.org/r/jsf/webtools.jsf.tests"/>
-      </subproject>
-      <subproject
-          name="Webtools Releng"
-          site="https://projects.eclipse.org/projects/webtools.releng">
-        <repository
-            uri="https://git.eclipse.org/r/webtools/webtools.maps"/>
-        <repository
-            uri="https://git.eclipse.org/r/webtools/webtools.releng"/>
-        <repository
-            uri="https://git.eclipse.org/r/webtools/webtools.releng.aggregator"/>
       </subproject>
       <subproject
           name="Eclipse Server Tools"
           site="https://projects.eclipse.org/projects/webtools.servertools">
         <repository
-            uri="https://git.eclipse.org/r/servertools/webtools.servertools"/>
-        <repository
-            uri="https://git.eclipse.org/r/servertools/webtools.servertools.devsupport"/>
-        <repository
-            uri="https://git.eclipse.org/r/servertools/webtools.servertools.docs"/>
-        <repository
-            uri="https://git.eclipse.org/r/servertools/webtools.servertools.tests"/>
+            uri="https://github.com/eclipse-servertools/servertools"/>
       </subproject>
       <subproject
           name="Eclipse WTP Source Editing"
           site="https://projects.eclipse.org/projects/webtools.sourceediting">
         <repository
-            uri="https://git.eclipse.org/r/sourceediting/webtools.sourceediting"/>
-        <repository
-            uri="https://git.eclipse.org/r/sourceediting/webtools.sourceediting.tests"/>
-        <repository
-            uri="https://git.eclipse.org/r/sourceediting/webtools.sourceediting.xpath"/>
-        <repository
-            uri="https://git.eclipse.org/r/sourceediting/webtools.sourceediting.xpath.tests"/>
-        <repository
-            uri="https://git.eclipse.org/r/sourceediting/webtools.sourceediting.xsl"/>
-        <repository
-            uri="https://git.eclipse.org/r/sourceediting/webtools.sourceediting.xsl.tests"/>
+            uri="https://github.com/eclipse-sourceediting/sourceediting"/>
       </subproject>
       <subproject
           name="Eclipse Web Services Tools"
           site="https://projects.eclipse.org/projects/webtools.webservices">
         <repository
-            uri="https://git.eclipse.org/r/webservices/webtools.webservices"/>
-        <repository
-            uri="https://git.eclipse.org/r/webservices/webtools.webservices.axis2"/>
-        <repository
-            uri="https://git.eclipse.org/r/webservices/webtools.webservices.jaxws"/>
+            uri="https://github.com/eclipse-webservices/webservices"/>
       </subproject>
     </project>
   </contribution>
@@ -419,10 +320,6 @@
           uri="https://github.com/eclipse-mylyn/org.eclipse.mylyn"/>
       <repository
           uri="https://github.com/eclipse-mylyn/org.eclipse.mylyn.docs"/>
-      <repository
-          uri="https://github.com/eclipse-mylyn/org.eclipse.mylyn.docs.intent.main"/>
-      <repository
-          uri="https://github.com/eclipse-mylyn/org.eclipse.mylyn.docs.vex"/>
     </project>
   </contribution>
   <contribution
@@ -436,10 +333,6 @@
           uri="https://github.com/eclipse-mylyn/org.eclipse.mylyn"/>
       <repository
           uri="https://github.com/eclipse-mylyn/org.eclipse.mylyn.docs"/>
-      <repository
-          uri="https://github.com/eclipse-mylyn/org.eclipse.mylyn.docs.intent.main"/>
-      <repository
-          uri="https://github.com/eclipse-mylyn/org.eclipse.mylyn.docs.vex"/>
     </project>
   </contribution>
   <contribution
@@ -447,12 +340,10 @@
     <project
         name="Eclipse CDT (C/C++ Development Tooling)"
         site="https://projects.eclipse.org/projects/tools.cdt"
-        version="https://projects.eclipse.org/projects/tools.cdt/releases/11.3.0"
-        releaseDate="2023-09-13">
+        version="https://projects.eclipse.org/projects/tools.cdt/releases/11.4.0"
+        releaseDate="2023-12-06">
       <repository
           uri="https://github.com/eclipse-cdt/cdt"/>
-      <repository
-          uri="https://github.com/eclipse-cdt/cdt-infra"/>
       <repository
           uri="https://github.com/eclipse-cdt/cdt-lsp"/>
     </project>
@@ -465,17 +356,7 @@
         version="https://projects.eclipse.org/projects/iot.embed-cdt/releases/6.4.0"
         releaseDate="2023-07-25">
       <repository
-          uri="https://github.com/eclipse-embed-cdt/Liqp"/>
-      <repository
-          uri="https://github.com/eclipse-embed-cdt/assets"/>
-      <repository
           uri="https://github.com/eclipse-embed-cdt/eclipse-plugins"/>
-      <repository
-          uri="https://github.com/eclipse-embed-cdt/org.eclipse.epp.packages"/>
-      <repository
-          uri="https://github.com/eclipse-embed-cdt/web-jekyll"/>
-      <repository
-          uri="https://github.com/eclipse-embed-cdt/web-preview"/>
     </project>
   </contribution>
   <contribution
@@ -494,20 +375,10 @@
     <project
         name="Eclipse Dynamic Languages Toolkit"
         site="https://projects.eclipse.org/projects/technology.dltk"
-        version="https://projects.eclipse.org/projects/technology.dltk/releases/6.3"
-        releaseDate="2023-06-16">
+        version="https://projects.eclipse.org/projects/technology.dltk/releases/6.4"
+        releaseDate="2023-09-12">
       <repository
           uri="https://git.eclipse.org/r/dltk/org.eclipse.dltk.core"/>
-      <repository
-          uri="https://git.eclipse.org/r/dltk/org.eclipse.dltk.javascript"/>
-      <repository
-          uri="https://git.eclipse.org/r/dltk/org.eclipse.dltk.python"/>
-      <repository
-          uri="https://git.eclipse.org/r/dltk/org.eclipse.dltk.releng"/>
-      <repository
-          uri="https://git.eclipse.org/r/dltk/org.eclipse.dltk.ruby"/>
-      <repository
-          uri="https://git.eclipse.org/r/dltk/org.eclipse.dltk.sh"/>
       <repository
           uri="https://git.eclipse.org/r/dltk/org.eclipse.dltk.tcl"/>
     </project>
@@ -523,8 +394,6 @@
           uri="https://github.com/eclipse-rap/org.eclipse.rap"/>
       <repository
           uri="https://github.com/eclipse-rap/org.eclipse.rap.tools"/>
-      <repository
-          uri="https://github.com/eclipse-rap/org.eclipse.rap.website"/>
     </project>
   </contribution>
   <contribution
@@ -543,16 +412,10 @@
     <project
         name="Eclipse CDO Model Repository"
         site="https://projects.eclipse.org/projects/modeling.emf.cdo"
-        version="https://projects.eclipse.org/projects/modeling.emf.cdo/releases/4.24.0"
-        releaseDate="2023-09-13">
+        version="https://projects.eclipse.org/projects/modeling.emf.cdo/releases/4.25.0"
+        releaseDate="2023-12-06">
       <repository
           uri="https://github.com/eclipse-cdo/cdo"/>
-      <repository
-          uri="https://github.com/eclipse-cdo/cdo.infrastructure"/>
-      <repository
-          uri="https://github.com/eclipse-cdo/cdo.old"/>
-      <repository
-          uri="https://github.com/eclipse-cdo/cdo.www"/>
     </project>
   </contribution>
   <contribution
@@ -571,8 +434,8 @@
     <project
         name="Eclipse Memory Analyzer"
         site="https://projects.eclipse.org/projects/tools.mat"
-        version="https://projects.eclipse.org/projects/tools.mat/releases/1.14.0"
-        releaseDate="2023-03-15">
+        version="https://projects.eclipse.org/projects/tools.mat/releases/1.15.0"
+        releaseDate="2023-12-06">
       <repository
           uri="https://git.eclipse.org/r/mat/org.eclipse.mat"/>
     </project>
@@ -586,7 +449,7 @@
         version="https://projects.eclipse.org/projects/modeling.mdt.uml2/releases/5.5.3"
         releaseDate="2022-12-07">
       <repository
-          uri="https://git.eclipse.org/r/uml2/org.eclipse.uml2"/>
+          uri="https://github.com/eclipse-uml2/uml2"/>
     </project>
   </contribution>
   <contribution
@@ -648,14 +511,10 @@
     <project
         name="Eclipse Xtext"
         site="https://projects.eclipse.org/projects/modeling.tmf.xtext"
-        version="https://projects.eclipse.org/projects/modeling.tmf.xtext/releases/2.32.0"
-        releaseDate="2023-08-28">
+        version="https://projects.eclipse.org/projects/modeling.tmf.xtext/releases/2.33.0"
+        releaseDate="2023-11-20">
       <repository
           uri="https://github.com/eclipse/xtext"/>
-      <repository
-          uri="https://github.com/eclipse/xtext-archive"/>
-      <repository
-          uri="https://github.com/eclipse/xtext-website-publish"/>
     </project>
   </contribution>
   <contribution
@@ -663,8 +522,8 @@
     <project
         name="Eclipse PHP Development Tools"
         site="https://projects.eclipse.org/projects/tools.pdt"
-        version="https://projects.eclipse.org/projects/tools.pdt/releases/8.0.0"
-        releaseDate="2023-06-14">
+        version="https://projects.eclipse.org/projects/tools.pdt/releases/8.1"
+        releaseDate="2023-09-12">
       <repository
           uri="https://github.com/eclipse-pdt/pdt"/>
     </project>
@@ -678,8 +537,6 @@
         releaseDate="2020-03-18">
       <repository
           uri="https://github.com/eclipse-ptp/ptp"/>
-      <repository
-          uri="https://github.com/eclipse-ptp/ptp.doc"/>
       <repository
           uri="https://github.com/eclipse-ptp/ptp.photran"/>
     </project>
@@ -724,18 +581,24 @@
     <project
         name="Eclipse EGit: Git Integration for Eclipse"
         site="https://projects.eclipse.org/projects/technology.egit"
-        version="https://projects.eclipse.org/projects/technology.egit/releases/6.7.0"
-        releaseDate="2023-09-13">
+        version="https://projects.eclipse.org/projects/technology.egit/releases/6.8.0"
+        releaseDate="2023-12-06">
       <repository
-          uri="https://git.eclipse.org/r/egit/egit"/>
+          uri="https://github.com/eclipse-egit/egit"/>
+      <repository
+          uri="https://github.com/eclipse-egit/egit-github"/>
+      <repository
+          uri="https://github.com/eclipse-egit/egit-permissions"/>
     </project>
     <project
         name="Eclipse JGit: Java implementation of Git"
         site="https://projects.eclipse.org/projects/technology.jgit"
-        version="https://projects.eclipse.org/projects/technology.jgit/releases/6.7.0"
-        releaseDate="2023-09-13">
+        version="https://projects.eclipse.org/projects/technology.jgit/releases/6.8.0"
+        releaseDate="2023-12-06">
       <repository
-          uri="https://git.eclipse.org/r/jgit/jgit"/>
+          uri="https://github.com/eclipse-jgit/jgit"/>
+      <repository
+          uri="https://github.com/eclipse-jgit/jgit-permissions"/>
     </project>
   </contribution>
   <contribution
@@ -803,15 +666,9 @@
         version="https://projects.eclipse.org/projects/technology.scout/releases/23.2"
         releaseDate="2023-09-13">
       <repository
-          uri="https://github.com/eclipse-scout/scout.ci"/>
-      <repository
-          uri="https://github.com/eclipse-scout/scout.maven-master"/>
-      <repository
           uri="https://github.com/eclipse-scout/scout.rt"/>
       <repository
           uri="https://github.com/eclipse-scout/scout.sdk"/>
-      <repository
-          uri="https://github.com/eclipse-scout/scout.website"/>
       <repository
           uri="https://github.com/eclipse/org.eclipse.scout.docs"/>
     </project>
@@ -847,9 +704,9 @@
         version="https://projects.eclipse.org/projects/tools.tcf/releases/1.7.0"
         releaseDate="2021-07-20">
       <repository
-          uri="https://git.eclipse.org/r/tcf/org.eclipse.tcf"/>
+          uri="https://gitlab.eclipse.org/eclipse/tcf/tcf"/>
       <repository
-          uri="https://git.eclipse.org/r/tcf/org.eclipse.tcf.agent"/>
+          uri="https://gitlab.eclipse.org/eclipse/tcf/tcf.agent"/>
     </project>
   </contribution>
   <contribution
@@ -864,10 +721,6 @@
           uri="https://github.com/eclipse-sirius/sirius-desktop"/>
       <repository
           uri="https://github.com/eclipse-sirius/sirius-emf-json"/>
-      <repository
-          uri="https://github.com/eclipse-sirius/sirius-specs"/>
-      <repository
-          uri="https://github.com/eclipse-sirius/sirius-web"/>
     </project>
   </contribution>
   <contribution
@@ -931,8 +784,8 @@
     <project
         name="Eclipse Buildship: Eclipse Plug-ins for Gradle"
         site="https://projects.eclipse.org/projects/tools.buildship"
-        version="https://projects.eclipse.org/projects/tools.buildship/releases/3.1.7"
-        releaseDate="2023-04-28">
+        version="https://projects.eclipse.org/projects/tools.buildship/releases/3.1.8"
+        releaseDate="2023-09-30">
       <repository
           uri="https://github.com/eclipse/buildship"/>
     </project>
@@ -953,16 +806,10 @@
     <project
         name="Eclipse VIATRA"
         site="https://projects.eclipse.org/projects/modeling.viatra"
-        version="https://projects.eclipse.org/projects/modeling.viatra/releases/2.7.1"
-        releaseDate="2022-08-30">
+        version="https://projects.eclipse.org/projects/modeling.viatra/releases/2.8.0"
+        releaseDate="2023-10-20">
       <repository
           uri="https://git.eclipse.org/r/viatra/org.eclipse.viatra"/>
-      <repository
-          uri="https://git.eclipse.org/r/viatra/org.eclipse.viatra.examples"/>
-      <repository
-          uri="https://git.eclipse.org/r/viatra/org.eclipse.viatra.modelobfuscator"/>
-      <repository
-          uri="https://git.eclipse.org/r/viatra/org.eclipse.viatra2.vpm"/>
     </project>
   </contribution>
   <contribution
@@ -970,8 +817,8 @@
     <project
         name="Eclipse EclEmma"
         site="https://projects.eclipse.org/projects/technology.eclemma"
-        version="https://projects.eclipse.org/projects/technology.eclemma/releases/3.1.7-0"
-        releaseDate="2023-06-07">
+        version="https://projects.eclipse.org/projects/technology.eclemma/releases/3.1.8"
+        releaseDate="2023-12-06">
       <repository
           uri="https://github.com/eclipse/eclemma"/>
     </project>
@@ -1019,10 +866,6 @@
         releaseDate="2022-07-05">
       <repository
           uri="https://github.com/eclipse/eclipse-collections"/>
-      <repository
-          uri="https://github.com/eclipse/eclipse-collections-kata"/>
-      <repository
-          uri="https://github.com/eclipse/gsc-ec-converter"/>
     </project>
   </contribution>
   <contribution
@@ -1056,8 +899,6 @@
         releaseDate="2023-09-13">
       <repository
           uri="https://github.com/eclipse-linuxtools/org.eclipse.linuxtools"/>
-      <repository
-          uri="https://github.com/eclipse-linuxtools/org.eclipse.linuxtools.eclipse-build"/>
     </project>
   </contribution>
   <contribution
@@ -1065,18 +906,10 @@
     <project
         name="Eclipse Passage"
         site="https://projects.eclipse.org/projects/technology.passage"
-        version="https://projects.eclipse.org/projects/technology.passage/releases/2.9.0"
-        releaseDate="2023-09-06">
-      <repository
-          uri="https://github.com/eclipse-passage/chronograph"/>
+        version="https://projects.eclipse.org/projects/technology.passage/releases/2.10.0"
+        releaseDate="2023-12-06">
       <repository
           uri="https://github.com/eclipse-passage/passage"/>
-      <repository
-          uri="https://github.com/eclipse-passage/passage-docs"/>
-      <repository
-          uri="https://github.com/eclipse-passage/passage-images"/>
-      <repository
-          uri="https://github.com/eclipse-passage/passage-spring"/>
     </project>
   </contribution>
   <contribution
@@ -1113,8 +946,6 @@
           uri="https://github.com/eclipse-rap/org.eclipse.rap"/>
       <repository
           uri="https://github.com/eclipse-rap/org.eclipse.rap.tools"/>
-      <repository
-          uri="https://github.com/eclipse-rap/org.eclipse.rap.website"/>
     </project>
   </contribution>
   <contribution
@@ -1132,18 +963,36 @@
     <project
         name="Eclipse Packaging Project"
         site="https://projects.eclipse.org/projects/technology.packaging"
-        version="https://projects.eclipse.org/projects/technology.packaging/releases/4.29.0"
-        releaseDate="2023-09-13">
+        version="https://projects.eclipse.org/projects/technology.packaging/releases/4.30.0"
+        releaseDate="2023-12-06">
       <repository
           uri="https://github.com/eclipse-packaging/packages"/>
     </project>
     <project
+        name="Eclipse SimRel"
+        site="https://projects.eclipse.org/projects/technology.simrel">
+      <repository
+          uri="https://github.com/eclipse-simrel/help.eclipse.org"/>
+      <repository
+          uri="https://github.com/eclipse-simrel/simrel.build"/>
+      <repository
+          uri="https://github.com/eclipse-simrel/simrel.tools"/>
+    </project>
+    <project
         name="Eclipse Tycho"
         site="https://projects.eclipse.org/projects/technology.tycho"
-        version="https://projects.eclipse.org/projects/technology.tycho/releases/4.0.2"
-        releaseDate="2023-08-21">
+        version="https://projects.eclipse.org/projects/technology.tycho/releases/4.0.3"
+        releaseDate="2023-09-30">
       <repository
           uri="https://github.com/eclipse-tycho/tycho"/>
+    </project>
+    <project
+        name="Eclipse Orbit Project"
+        site="https://projects.eclipse.org/projects/tools.orbit">
+      <repository
+          uri="https://github.com/eclipse-orbit/orbit-legacy"/>
+      <repository
+          uri="https://github.com/eclipse-orbit/orbit-simrel"/>
     </project>
   </contribution>
 </analyzer:Analysis>

--- a/sirius.aggrcon
+++ b/sirius.aggrcon
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="ASCII"?>
 <aggregator:Contribution xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:aggregator="http://www.eclipse.org/cbi/p2repo/2011/aggregator/1.1.0" description="Eclipse Sirius" label="Sirius Desktop">
-  <repositories location="https://download.eclipse.org/sirius/updates/milestones/7.3.0rc1/2023-03">
+  <repositories location="https://download.eclipse.org/sirius/updates/releases/7.3.0/2023-03">
     <features name="org.eclipse.sirius.specifier.feature.group">
       <categories href="simrel.aggr#//@customCategories[identifier='Modeling']"/>
     </features>

--- a/sirius.aggrcon
+++ b/sirius.aggrcon
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="ASCII"?>
 <aggregator:Contribution xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:aggregator="http://www.eclipse.org/cbi/p2repo/2011/aggregator/1.1.0" description="Eclipse Sirius" label="Sirius Desktop">
-  <repositories location="https://download.eclipse.org/sirius/updates/releases/7.2.1/2023-03/">
+  <repositories location="https://download.eclipse.org/sirius/updates/milestones/7.3.0rc1/2023-03">
     <features name="org.eclipse.sirius.specifier.feature.group">
       <categories href="simrel.aggr#//@customCategories[identifier='Modeling']"/>
     </features>

--- a/tmf-xtext.aggrcon
+++ b/tmf-xtext.aggrcon
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="ASCII"?>
 <aggregator:Contribution xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:aggregator="http://www.eclipse.org/cbi/p2repo/2011/aggregator/1.1.0" label="Xtext, Xtend">
-  <repositories location="https://download.eclipse.org/modeling/tmf/xtext/updates/milestones/2.33.0.M3/" description="Xtext p2 repository">
-    <features name="org.eclipse.xtext.sdk.feature.group" versionRange="[2.33.0.v20231112-1245]">
+  <repositories location="https://download.eclipse.org/modeling/tmf/xtext/updates/releases/2.33.0" description="Xtext p2 repository">
+    <features name="org.eclipse.xtext.sdk.feature.group" versionRange="[2.33.0.v20231121-0955]">
       <categories href="simrel.aggr#//@customCategories[identifier='Modeling']"/>
       <categories href="simrel.aggr#//@customCategories[identifier='General%20Purpose%20Tools']"/>
     </features>
-    <features name="org.eclipse.xtend.sdk.feature.group" versionRange="[2.33.0.v20231112-1245]">
+    <features name="org.eclipse.xtend.sdk.feature.group" versionRange="[2.33.0.v20231121-0955]">
       <categories href="simrel.aggr#//@customCategories[identifier='Programming%20Languages']"/>
     </features>
   </repositories>

--- a/tracecompass.aggrcon
+++ b/tracecompass.aggrcon
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="ASCII"?>
 <aggregator:Contribution xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:aggregator="http://www.eclipse.org/cbi/p2repo/2011/aggregator/1.1.0" description="Trace Compass Updates" label="Trace Compass">
-  <repositories location="https://download.eclipse.org/tracecompass/2023-12/milestones/m3/" description="Trace Compass Updates">
+  <repositories location="https://download.eclipse.org/tracecompass/2023-12/milestones/rc1/" description="Trace Compass Updates">
     <features name="org.eclipse.tracecompass.lttng2.control.feature.group" versionRange="0.1.0"/>
     <features name="org.eclipse.tracecompass.lttng2.kernel.feature.group" versionRange="0.1.0">
       <categories href="simrel.aggr#//@customCategories[identifier='Performance%2C%20Profiling%20and%20Tracing%20Tools']"/>

--- a/wildwebdeveloper.aggrcon
+++ b/wildwebdeveloper.aggrcon
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="ASCII"?>
 <aggregator:Contribution xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:aggregator="http://www.eclipse.org/cbi/p2repo/2011/aggregator/1.1.0" label="Wild Web Developer">
-  <repositories location="https://download.eclipse.org/wildwebdeveloper/releases/1.3.2/" description="Wild Web Developer 1.3.2">
-    <features name="org.eclipse.wildwebdeveloper.feature.feature.group" versionRange="[1.3.2.202311162216]">
+  <repositories location="https://download.eclipse.org/wildwebdeveloper/releases/1.3.3/" description="Wild Web Developer 1.3.3">
+    <features name="org.eclipse.wildwebdeveloper.feature.feature.group" versionRange="[1.3.3.202311211923]">
       <categories href="simrel.aggr#//@customCategories[identifier='Programming%20Languages']"/>
       <categories href="simrel.aggr#//@customCategories[identifier='Web%2C%20XML%2C%20Java%20EE%20and%20OSGi%20Enterprise%20Development']"/>
     </features>

--- a/wildwebdeveloper.aggrcon
+++ b/wildwebdeveloper.aggrcon
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="ASCII"?>
 <aggregator:Contribution xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:aggregator="http://www.eclipse.org/cbi/p2repo/2011/aggregator/1.1.0" label="Wild Web Developer">
-  <repositories location="https://download.eclipse.org/wildwebdeveloper/releases/1.3.1/" description="Wild Web Developer 1.3.1">
-    <features name="org.eclipse.wildwebdeveloper.feature.feature.group" versionRange="[1.3.1.202311151451]">
+  <repositories location="https://download.eclipse.org/wildwebdeveloper/releases/1.3.2/" description="Wild Web Developer 1.3.2">
+    <features name="org.eclipse.wildwebdeveloper.feature.feature.group" versionRange="[1.3.2.202311162216]">
       <categories href="simrel.aggr#//@customCategories[identifier='Programming%20Languages']"/>
       <categories href="simrel.aggr#//@customCategories[identifier='Web%2C%20XML%2C%20Java%20EE%20and%20OSGi%20Enterprise%20Development']"/>
     </features>

--- a/windowbuilder.aggrcon
+++ b/windowbuilder.aggrcon
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="ASCII"?>
 <aggregator:Contribution xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:aggregator="http://www.eclipse.org/cbi/p2repo/2011/aggregator/1.1.0" description="Window Builder GUI Designer" label="Window Builder">
-  <repositories location="https://download.eclipse.org/windowbuilder/updates/milestone/S202311141707" description="WindowBuilder 1.14.0">
+  <repositories location="https://download.eclipse.org/windowbuilder/updates/milestone/S202311211642" description="WindowBuilder 1.14.0">
     <features name="org.eclipse.wb.core.feature.feature.group">
       <categories href="simrel.aggr#//@customCategories[identifier='General%20Purpose%20Tools']"/>
     </features>

--- a/windowbuilder.aggrcon
+++ b/windowbuilder.aggrcon
@@ -34,7 +34,7 @@
     <features name="org.eclipse.wb.swing.doc.user.feature.feature.group">
       <categories href="simrel.aggr#//@customCategories[identifier='General%20Purpose%20Tools']"/>
     </features>
-    <features name="org.eclipse.wb.xwt.feature.feature.group">
+    <features name="org.eclipse.wb.xwt.feature.feature.group" enabled="false">
       <categories href="simrel.aggr#//@customCategories[identifier='General%20Purpose%20Tools']"/>
     </features>
     <features name="org.eclipse.wb.core.xml.feature.feature.group">

--- a/xwt.aggrcon
+++ b/xwt.aggrcon
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="ASCII"?>
-<aggregator:Contribution xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:aggregator="http://www.eclipse.org/cbi/p2repo/2011/aggregator/1.1.0" description="XWT - Declarative UI in XML for Eclipse" label="XWT">
+<aggregator:Contribution xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:aggregator="http://www.eclipse.org/cbi/p2repo/2011/aggregator/1.1.0" enabled="false" description="XWT - Declarative UI in XML for Eclipse" label="XWT">
   <repositories location="https://download.eclipse.org/xwt/release-1.9.0/">
     <features description="XWT Runtime" name="org.eclipse.xwt.feature.feature.group" versionRange="1.9.0">
       <categories href="simrel.aggr#//@customCategories[identifier='General%20Purpose%20Tools']"/>


### PR DESCRIPTION
- EMF Parsley 1.15.0 M1 (#77)
- [MPC] MPC 1.10.2 contribution for 2023-12 RC1
- Simrel updates for Eclipse and Equinox for 2023-12 RC1 (#79)
- MWE(2) 1.10.0/2.16.0 for Eclipse 2023-12 (#81)
- Ensure that MWE mirrors artifacts.
- [qvto] 3.10.8SR1 for 2023-12 (#85)
- Contribute Buildship 3.1.8 (#83)
- [modisco] 1.5.3SR1 for 2023-12 (#86)
- EMF Compare 3.3.23RC1 and Acceleo 3.7.14RC1 for 2023-12RC1
- Upgrade WildWebDeveloper to v.1.3.2
- Eclipse Memory Analyzer contribution to SimRel 2023-12 RC1 (#89)
- GMF Runtime 1.16.2rc1 and Sirius Desktop 7.3.0rc1 (#90)
- Eclipse Scout SDK 13.0.26 with Scout RT 23.2.13 for SimRel 2023-12 RC1 (#91)
- Update to EMF 2.36 release for RC1
- [ocl,qvtd] 6.19.0SR1, 0.30.0SR1 for 2023-12 (#93)
- Disable XWT from the aggregation
- Disable RCPTT
- Contribute DataTools 1.16.0 release for RC1
- contribute released EMF Parsley 1.15.0 (#98)
- Contribute Xtext 2.33.0 (#95)
- Contribute WindowBuilder RC1 for SimRel 2023-12
- Upgrade WildWebDeveloper to v.1.3.3
- CDT 11.4.0 RC1a for 2023-12 RC1 (#102)
- Update Linux Tools for 2023-12 RC1 (#104)
- Contribute JGit/EGit 6.8.0.202311212206-rc1 to 2023-12 RC1 (#105)
- Reduce PTP's contribution to the bare minimum
- Publish RAP 3.27 RC1 for 2023-12 RC1 (#107)
- Contribute Oomph 1.31 RC1 for 2023-12 RC1
- Contribute Mylyn 4.10.0 RC1 for 2023-12 RC1
- CDO 4.25-RC1 (#110)
- Contribute GEF FX RC1 for 2023-12 RC1
- Contribute Passage 2.10.0 RC1 for 2023-12 RC1
- GEF Classic 3.18.0RC1 for 2023-12 RC1 (#113)
- Trace Compass contribution for 2023-12 RC1
- GMF Runtime 1.16.2 final
- Update to LSP4E 0.24.5
- Simrel updates for Eclipse and Equinox for 2023-12 RC2 (#117)
- Remove simrel-extras from the aggregation
- Remove ECF's httpclient5 explicit feature include
- Contribute (patched) EMF Parsley 1.15.0 (#120)
- [qvto] 3.10.8 for 2023-12 (#121)
- [modisco] 1.5.3 for 2023-12 (#122)
- Sirius Desktop 7.3.0 final
